### PR TITLE
クイックリトライ時にもノーツ数を送信する機能の追加(oraja_helper向け)

### DIFF
--- a/core/src/bms/player/beatoraja/external/OrajaHelperClient.java
+++ b/core/src/bms/player/beatoraja/external/OrajaHelperClient.java
@@ -40,6 +40,18 @@ public final class OrajaHelperClient {
 		send(payload);
 	}
 
+	public static void sendPlayEnd(SongData song, ReplayData replay, Mode mode, int playedNotes, int totalNotes,
+			long elapsedSeconds, boolean quickRetry) {
+		Map<String, Object> payload = basePayload("song_play_end", "play", song);
+		addOption(payload, replay, mode);
+		payload.put("playEndMetrics", true);
+		payload.put("playedNotes", playedNotes);
+		payload.put("totalNotes", totalNotes);
+		payload.put("elapsedSeconds", elapsedSeconds);
+		payload.put("quickRetry", quickRetry);
+		send(payload);
+	}
+
 	public static void sendResult(SongData song, ReplayData replay, Mode mode, ScoreData score) {
 		if (score == null) {
 			return;

--- a/core/src/bms/player/beatoraja/external/OrajaHelperClient.java
+++ b/core/src/bms/player/beatoraja/external/OrajaHelperClient.java
@@ -40,8 +40,8 @@ public final class OrajaHelperClient {
 		send(payload);
 	}
 
-	public static void sendPlayEnd(SongData song, ReplayData replay, Mode mode, int playedNotes, int totalNotes,
-			long elapsedSeconds, boolean quickRetry) {
+	public static void sendPlayEnd(SongData song, ReplayData replay, Mode mode, ScoreData score, int playedNotes,
+			int totalNotes, long elapsedSeconds, boolean quickRetry) {
 		Map<String, Object> payload = basePayload("song_play_end", "play", song);
 		addOption(payload, replay, mode);
 		payload.put("playEndMetrics", true);
@@ -49,6 +49,9 @@ public final class OrajaHelperClient {
 		payload.put("totalNotes", totalNotes);
 		payload.put("elapsedSeconds", elapsedSeconds);
 		payload.put("quickRetry", quickRetry);
+		if (score != null) {
+			payload.put("judges", judgePayload(score));
+		}
 		send(payload);
 	}
 

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -965,7 +965,7 @@ public class BMSPlayer extends MainState {
 			return;
 		}
 		int playedNotes = Math.max(0, judge.getPastNotes());
-\t\tint totalNotes = Math.max(0, model != null ? model.getTotalNotes() : (resource.getSongdata() != null ? resource.getSongdata().getNotes() : 0));
+		int totalNotes = Math.max(0, model != null ? model.getTotalNotes() : (resource.getSongdata() != null ? resource.getSongdata().getNotes() : 0));
 		long elapsedSeconds = timer.isTimerOn(TIMER_PLAY) ? Math.max(0, timer.getNowTime(TIMER_PLAY) / 1000) : 0;
 		OrajaHelperClient.sendPlayEnd(resource.getSongdata(), playinfo, model != null ? model.getMode() : null,
 				judge.getScoreData(), playedNotes, totalNotes, elapsedSeconds, quickRetry);

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -968,7 +968,7 @@ public class BMSPlayer extends MainState {
 		int totalNotes = Math.max(0, model != null ? model.getTotalNotes() : resource.getSongdata().getNotes());
 		long elapsedSeconds = timer.isTimerOn(TIMER_PLAY) ? Math.max(0, timer.getNowTime(TIMER_PLAY) / 1000) : 0;
 		OrajaHelperClient.sendPlayEnd(resource.getSongdata(), playinfo, model != null ? model.getMode() : null,
-				playedNotes, totalNotes, elapsedSeconds, quickRetry);
+				judge.getScoreData(), playedNotes, totalNotes, elapsedSeconds, quickRetry);
 		playEndMetricsSent = true;
 	}
 

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -101,6 +101,7 @@ public class BMSPlayer extends MainState {
 	private float adjustedVolume = -1.f;
 	private boolean analysisChecked = false;
 	private Future<BMSLoudnessAnalyzer.AnalysisResult> analysisTask;
+	private boolean playEndMetricsSent = false;
 
 	public BMSPlayer(MainController main, PlayerResource resource) {
 		super(main);
@@ -838,6 +839,7 @@ public class BMSPlayer extends MainState {
 				if ((input.startPressed() ^ input.isSelectPressed()) && resource.getCourseBMSModels() == null
 						&& autoplay.mode == BMSPlayerMode.Mode.PLAY) {
                     main.getAudioProcessor().setGlobalPitch(1f);
+					sendPlayEndMetrics(true);
 					if (!resource.isUpdateScore()) {
 						resource.getReplayData().randomoptionseed = -1;
 						logger.info("アシストモード時は同じ譜面でリプレイできません");
@@ -859,6 +861,7 @@ public class BMSPlayer extends MainState {
 					if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.REPLAY) {
 						resource.setScoreData(createScoreData());
 					}
+					sendPlayEndMetrics(false);
 					resource.setCombo(judge.getCourseCombo());
 					resource.setMaxcombo(judge.getCourseMaxcombo());
 					saveConfig();
@@ -899,6 +902,7 @@ public class BMSPlayer extends MainState {
 					if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.REPLAY) {
 						resource.setScoreData(createScoreData());
 					}
+					sendPlayEndMetrics(false);
 					resource.setCombo(judge.getCourseCombo());
 					resource.setMaxcombo(judge.getCourseMaxcombo());
 					saveConfig();
@@ -930,6 +934,7 @@ public class BMSPlayer extends MainState {
 				if ((resource.getPlayMode().mode == BMSPlayerMode.Mode.PLAY
 						&& input.startPressed() ^ input.isSelectPressed()) && resource.getCourseBMSModels() == null) {
 					main.getAudioProcessor().setGlobalPitch(1f);
+					sendPlayEndMetrics(true);
 					if (!resource.isUpdateScore()) {
 						resource.getReplayData().randomoptionseed = -1;
 						logger.info("アシストモード時は同じ譜面でリプレイできません");
@@ -953,6 +958,18 @@ public class BMSPlayer extends MainState {
 		}
 
 		prevtime = micronow;
+	}
+
+	private void sendPlayEndMetrics(boolean quickRetry) {
+		if (playEndMetricsSent || judge == null) {
+			return;
+		}
+		int playedNotes = Math.max(0, judge.getPastNotes());
+		int totalNotes = Math.max(0, model != null ? model.getTotalNotes() : resource.getSongdata().getNotes());
+		long elapsedSeconds = timer.isTimerOn(TIMER_PLAY) ? Math.max(0, timer.getNowTime(TIMER_PLAY) / 1000) : 0;
+		OrajaHelperClient.sendPlayEnd(resource.getSongdata(), playinfo, model != null ? model.getMode() : null,
+				playedNotes, totalNotes, elapsedSeconds, quickRetry);
+		playEndMetricsSent = true;
 	}
 
 	public void setPlaySpeed(int playspeed) {

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -965,7 +965,7 @@ public class BMSPlayer extends MainState {
 			return;
 		}
 		int playedNotes = Math.max(0, judge.getPastNotes());
-		int totalNotes = Math.max(0, model != null ? model.getTotalNotes() : resource.getSongdata().getNotes());
+\t\tint totalNotes = Math.max(0, model != null ? model.getTotalNotes() : (resource.getSongdata() != null ? resource.getSongdata().getNotes() : 0));
 		long elapsedSeconds = timer.isTimerOn(TIMER_PLAY) ? Math.max(0, timer.getNowTime(TIMER_PLAY) / 1000) : 0;
 		OrajaHelperClient.sendPlayEnd(resource.getSongdata(), playinfo, model != null ? model.getMode() : null,
 				judge.getScoreData(), playedNotes, totalNotes, elapsedSeconds, quickRetry);


### PR DESCRIPTION
oraja_helper向けにもう1点機能追加させてください。

# 追加した機能
- プレー画面終了時に判定内訳及び演奏時間を送信する機能を追加

用途としては、クイックリトライを多用する場合でもプレー曲数・プレー画面の累計時間、スコアレートを適切に算出するためです。
play_endとresultの両方のイベントが送られても重複してカウントしないようにoraja_helper側で対処します。