### PR TITLE
未Easyランセレなどのために、random/default.jsonで不等式を使えるようにした。

### DIFF
--- a/assets/random/default.json
+++ b/assets/random/default.json
@@ -1,17 +1,47 @@
 [
 	{
-		"name":"RANDOM SELECT"
+		"name": "RANDOM SELECT"
 	},
 	{
-		"name":"NO PLAY RANDOM SELECT",
+		"name": "NO PLAY RANDOM SELECT",
 		"filter": {
 			"playcount": 0
 		}
 	},
 	{
-		"name":"FAILED RANDOM SELECT",
+		"name": "FAILED RANDOM SELECT",
 		"filter": {
 			"clear": 1
+		}
+	},
+	{
+		"name": "NOT EASY RANDOM SELECT",
+		"filter": {
+			"clear": "<=3"
+		}
+	},
+	{
+		"name": "NOT CLEAR RANDOM SELECT",
+		"filter": {
+			"clear": "<=4"
+		}
+	},
+	{
+		"name": "NOT HARD RANDOM SELECT",
+		"filter": {
+			"clear": "<=5"
+		}
+	},
+	{
+		"name": "NOT EX-HARD RANDOM SELECT",
+		"filter": {
+			"clear": "<=6"
+		}
+	},
+	{
+		"name": "NOT FULL COMBO RANDOM SELECT",
+		"filter": {
+			"clear": "<=7"
 		}
 	}
 ]

--- a/core/src/bms/player/beatoraja/select/BarManager.java
+++ b/core/src/bms/player/beatoraja/select/BarManager.java
@@ -488,34 +488,9 @@ public class BarManager {
 										songBar -> songBar instanceof SongBar && ((SongBar) songBar).getSongData().getPath() != null)
 								.map(songBar -> ((SongBar) songBar).getSongData()).toArray(SongData[]::new);
 						if (randomFolder.getFilter() != null) {
-							Set<String> filterKey = randomFolder.getFilter().keySet();
 							randomTargets = Stream.of(randomTargets).filter(r -> {
 								ScoreData scoreData = select.getScoreDataCache().readScoreData(r, config.getLnmode());
-								for (String key : filterKey) {
-									String getterMethodName = "get" + key.substring(0, 1).toUpperCase()
-											+ key.substring(1);
-									try {
-										Object value = randomFolder.getFilter().get(key);
-										if (scoreData == null) {
-											if (value instanceof String && !"".equals((String) value)) {
-												return false;
-											}
-											if (value instanceof Integer && 0 != (Integer) value) {
-												return false;
-											}
-										} else {
-											Method getterMethod = ScoreData.class.getMethod(getterMethodName);
-											Object propertyValue = getterMethod.invoke(scoreData);
-											if (!propertyValue.equals(value)) {
-												return false;
-											}
-										}
-									} catch (Throwable e) {
-										e.printStackTrace();
-										return false;
-									}
-								}
-								return true;
+								return randomFolder.filterSong(scoreData);
 							}).toArray(SongData[]::new);
 						}
 						if ((randomFolder.getFilter() != null && randomTargets.length >= 1)


### PR DESCRIPTION
選曲画面におけるランダムセレクト機能強化のために、`assets/random/default.json`において不等式を指定可能にしました。
未難からランダムセレクト(clear, easy, assist, failed, noplayの中からランダム)のような選択が可能となります。

デフォルトの`NO PLAY RANDOM SELECT`や`FAILED RANDOM SELECT`は不要になりそうな気がしますが残しています。  
<img width="900" alt="20260609_013533_LR2oraja_Music_Select" src="https://github.com/user-attachments/assets/b25ff4dd-8591-4b8f-9d1e-9208233b32b2" />
