### PR TITLE
Document BMS-IR compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ Once you're set up with a copy of LR2oraja Endless Dream you might want to check
 
 Alternatively you can ask in our [Discord](https://discord.gg/HutCHCZHns) and we'll be happy to help you out.
 
+### BMS-IR compatibility
+
+When connecting this fork to [BMS-IR](https://www.bms-ir.org/), use the BMS-IR
+plugin build for LR2oraja Endless Dream. The plugin reports the host jar hash
+and `client_kind=lr2oraja-ed`, which lets BMS-IR keep this client in the
+LR2oraja ED bucket.
+
+For public BMS-IR allowlist registration, publish versioned release jars and
+share their MD5 and SHA-256 hashes. Locally built jars can have different hashes
+and are not suitable as stable allowlist entries.
+
+DX MODE scores should remain excluded from non-rianIR uploads. This matches the
+current `IRUtil.shouldSkipIR` behavior and is required for BMS-IR compatibility.
+
 ## Building from source
 A JDK 17 **with javafx** is required to build and run. Consider using [liberica JDK](https://bell-sw.com/pages/downloads/#jdk-17-lts), ensure that you download `Package: Full JDK` to get the JavaFX version.
 


### PR DESCRIPTION
## Summary

- document the minimum BMS-IR compatibility requirements for this fork
- update the `jbms-parser` submodule pointer to an available upstream commit so the project can be cloned and built with submodules

## Notes

While preparing a provisional BMS-IR connection test build, `git submodule update --init --recursive` failed because `core/dependencies/jbms-parser` pointed at `dcea0e4dfd77eae04e097c2d40d9703ee459f012`, which GitHub no longer served from `seraxis/jbms-parser`. I updated the submodule pointer to the current available `seraxis/jbms-parser` master commit (`52c5ddcb6bf96a2688c36fee30586c89bfe49f99`).

For BMS-IR allowlist registration, BMS-IR needs stable release jars and their MD5/SHA-256 hashes. Local builds are useful for testing, but official GitHub Release assets are preferred for production allowlisting.

## Test

Built successfully with Liberica JDK 17 Full:

```powershell
.\gradlew.bat core:shadowJar -Dplatform=windows --no-daemon --console=plain
```