### PR TITLE
Document BMS-IR score attack table delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,14 @@ plugin build for LR2oraja Endless Dream. The plugin reports the host jar hash
 and `client_kind=lr2oraja-ed`, which lets BMS-IR keep this client in the
 LR2oraja ED bucket.
 
-BMS-IR plugin `0.0.32` also supports primary-IR table delivery for active
+BMS-IR plugin `0.0.33` also supports primary-IR table delivery for active
 BMS-IR score attack one-chart courses. Set BMS-IR as the primary IR if you want
 those courses to appear in music select.
 
-Version `0.0.32` is recommended because it also reports wrong BMS-IR
+Version `0.0.33` is recommended because it also reports wrong BMS-IR
 ID/password combinations as login failures instead of falling back to read-only
-mode.
+mode, and preserves extended clear types such as EX HARD from BMS-IR ranking
+XML.
 
 For public BMS-IR allowlist registration, publish versioned release jars and
 share their MD5 and SHA-256 hashes. Locally built jars can have different hashes

--- a/README.md
+++ b/README.md
@@ -65,9 +65,13 @@ plugin build for LR2oraja Endless Dream. The plugin reports the host jar hash
 and `client_kind=lr2oraja-ed`, which lets BMS-IR keep this client in the
 LR2oraja ED bucket.
 
-BMS-IR plugin `0.0.30` also supports primary-IR table delivery for active
+BMS-IR plugin `0.0.32` also supports primary-IR table delivery for active
 BMS-IR score attack one-chart courses. Set BMS-IR as the primary IR if you want
 those courses to appear in music select.
+
+Version `0.0.32` is recommended because it also reports wrong BMS-IR
+ID/password combinations as login failures instead of falling back to read-only
+mode.
 
 For public BMS-IR allowlist registration, publish versioned release jars and
 share their MD5 and SHA-256 hashes. Locally built jars can have different hashes

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ plugin build for LR2oraja Endless Dream. The plugin reports the host jar hash
 and `client_kind=lr2oraja-ed`, which lets BMS-IR keep this client in the
 LR2oraja ED bucket.
 
+BMS-IR plugin `0.0.30` also supports primary-IR table delivery for active
+BMS-IR score attack one-chart courses. Set BMS-IR as the primary IR if you want
+those courses to appear in music select.
+
 For public BMS-IR allowlist registration, publish versioned release jars and
 share their MD5 and SHA-256 hashes. Locally built jars can have different hashes
 and are not suitable as stable allowlist entries.


### PR DESCRIPTION
BMS-IR compatibility note update.

- Documents that BMS-IR plugin 0.0.30 supports primary-IR table delivery for active BMS-IR score attack one-chart courses.
- Clarifies that users should set BMS-IR as the primary IR when they want those courses to appear in music select.
- Documentation only; no runtime code changes in this repository.