### PR TITLE
Replace legacy LR2IR links with BMS-IR links

### DIFF
--- a/core/src/bms/player/beatoraja/external/WebhookHandler.java
+++ b/core/src/bms/player/beatoraja/external/WebhookHandler.java
@@ -237,9 +237,9 @@ public class WebhookHandler {
         var song = currentState.resource.getSongdata();
         String ss = "";
         var md5 = song.getMd5();
-        String lr2ir =
-                "http://www.dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsmd5=";
-        if (md5 != null) { ss += " [LR2IR](" + lr2ir + md5 + ")"; }
+        String bmsir =
+        "https://www.bms-ir.org/new/song?songmd5=";
+        if (md5 != null) { ss += " [BMS-IR](" + bmsir + md5 + ")"; }
         String charturl = "https://bms-score-viewer.pages.dev/view?md5=";
         if (md5 != null) ss += " |";
         ss += " [Chart](" + charturl + md5 + ")";

--- a/core/src/bms/player/beatoraja/select/bar/ContextMenuBar.java
+++ b/core/src/bms/player/beatoraja/select/bar/ContextMenuBar.java
@@ -227,13 +227,13 @@ public class ContextMenuBar extends DirectoryBar {
     }
 
     private void addMetaEntries(ArrayList<Bar> options) {
-        var lr2irPage = new FunctionBar((selector, self) -> {
-            String urlBase =
-                "http://www.dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsmd5=";
-            boolean success = ContextMenuBar.browserOpen(urlBase + song.getMd5());
-            selector.play(success ? FOLDER_OPEN : OPTION_CHANGE);
-        }, "Open LR2IR page", STYLE_FOLDER);
-        if (song.getMd5() != null) options.add(lr2irPage);
+        var bmsirPage = new FunctionBar((selector, self) -> {
+    String urlBase =
+        "https://www.bms-ir.org/new/song?songmd5=";
+    boolean success = ContextMenuBar.browserOpen(urlBase + song.getMd5());
+    selector.play(success ? FOLDER_OPEN : OPTION_CHANGE);
+}, "Open BMS-IR page", STYLE_FOLDER);
+        if (song.getMd5() != null) options.add(bmsirPage);
 
         var chartViewer = new FunctionBar((selector, self) -> {
             String urlBase = "https://bms-score-viewer.pages.dev/view?md5=";


### PR DESCRIPTION
コーディングに関する知識が無く、ChatGPTと対話しながら行ったので至らぬ点があればすみません。

This fork already supports BMS-IR, but some user-facing links still point to the legacy LR2IR website.

This PR updates:

* Discord score card links in `WebhookHandler`
* "Open LR2IR page" in `ContextMenuBar`

Both links now point to the corresponding BMS-IR song page.

Tested locally:

* Build successful
* BMS-IR page link opens correctly from the context menu
