### PR TITLE
fix: 判定自動調節およびカスタムフォルダSQLエラーの修正、バージョンを1.2.5に更新

### DIFF
--- a/core/src/bms/player/beatoraja/Version.java
+++ b/core/src/bms/player/beatoraja/Version.java
@@ -10,7 +10,7 @@ public class Version {
     private static final Logger logger = LoggerFactory.getLogger(Version.class);
     public static final int VERSION_MAJOR = 1;
     public static final int VERSION_MINOR = 2;
-    public static final int VERSION_PATCH = 1;
+    public static final int VERSION_PATCH = 5;
 
     public static final BuildType BUILD_TYPE;
     public static final String version;
@@ -26,7 +26,7 @@ public class Version {
         BUILD_TYPE = BuildType.PRERELEASE;
         unqualifiedVersion = String.valueOf(VERSION_MAJOR) + '.' + VERSION_MINOR + '.' + VERSION_PATCH;
         version = BUILD_TYPE.prefix + unqualifiedVersion;
-        versionLong = "LR2oraja Endless Dream-RIAN" +  unqualifiedVersion + "-beta.1";
+        versionLong = "LR2oraja Endless Dream-RIAN" +  unqualifiedVersion;
         tryLoadingBuildMetaInfo();
     }
 

--- a/core/src/bms/player/beatoraja/Version.java
+++ b/core/src/bms/player/beatoraja/Version.java
@@ -10,7 +10,7 @@ public class Version {
     private static final Logger logger = LoggerFactory.getLogger(Version.class);
     public static final int VERSION_MAJOR = 1;
     public static final int VERSION_MINOR = 2;
-    public static final int VERSION_PATCH = 0;
+    public static final int VERSION_PATCH = 1;
 
     public static final BuildType BUILD_TYPE;
     public static final String version;
@@ -26,7 +26,7 @@ public class Version {
         BUILD_TYPE = BuildType.PRERELEASE;
         unqualifiedVersion = String.valueOf(VERSION_MAJOR) + '.' + VERSION_MINOR + '.' + VERSION_PATCH;
         version = BUILD_TYPE.prefix + unqualifiedVersion;
-        versionLong = "LR2oraja Endless Dream-RIAN" +  unqualifiedVersion;
+        versionLong = "LR2oraja Endless Dream-RIAN" +  unqualifiedVersion + "-beta.1";
         tryLoadingBuildMetaInfo();
     }
 

--- a/core/src/bms/player/beatoraja/play/ControlInputProcessor.java
+++ b/core/src/bms/player/beatoraja/play/ControlInputProcessor.java
@@ -313,7 +313,7 @@ public final class ControlInputProcessor {
 			|| (pmsSwitchLaneCover && !lanerender.isEnableLanecover() && !lanerender.isEnableLift() && !lanerender.isEnableHidden())) {
 			if(input.isAnalogInput(key)) {
 				// 【修正】 アナログ入力（スクラッチ）の場合は、変化量 × 0.01 を加算する
-				int dTicks = input.getAnalogDiffAndReset(key, 200) * (up ? 1 : -1);
+				int dTicks = input.getAnalogDiffAndReset(key, 200) * (up ? -1 : 1);
 				if (dTicks != 0) {
 					lanerender.addHispeed(dTicks * 0.01f);
 				}

--- a/core/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/core/src/bms/player/beatoraja/play/JudgeManager.java
@@ -768,7 +768,12 @@ public class JudgeManager {
                     pressesSinceLastAutoadjust++;
                     if (pressesSinceLastAutoadjust > 9) {
                         if (mfast <= -500 || mfast >= 500) {
-                            pc.setJudgetiming(pc.getJudgetiming() + (int) (mfast < 0 ? 1 : -1));
+                            int nextTiming = pc.getJudgetiming() + (int) (mfast < 0 ? 1 : -1);
+                            nextTiming = com.badlogic.gdx.math.MathUtils.clamp(nextTiming, PlayConfig.JUDGETIMING_MIN, PlayConfig.JUDGETIMING_MAX);
+                            pc.setJudgetiming(nextTiming);
+                            if (main.getLanerender() != null) {
+                                main.getLanerender().getPlayConfig().setJudgetiming(nextTiming);
+                            }
                         }
                         pressesSinceLastAutoadjust = 0;
                     }

--- a/core/src/bms/player/beatoraja/select/bar/CommandBar.java
+++ b/core/src/bms/player/beatoraja/select/bar/CommandBar.java
@@ -39,29 +39,39 @@ public class CommandBar extends DirectoryBar {
     @Override
     public Bar[] getChildren() {
     	final MainController main = selector.main;
-        String effectiveSql = sql;
-        if (effectiveSql.contains("score.") || effectiveSql.contains("scorelog.")) {
-            int lnmode = main.getPlayerConfig().getLnmode();
-            effectiveSql = "(" + effectiveSql + ") AND score.mode = (CASE WHEN (song.feature & 1) != 0 THEN " + lnmode + " ELSE 0 END)";
-            if (sql.contains("scorelog.")) {
-                effectiveSql += " AND (scorelog.sha256 IS NULL OR scorelog.mode = (CASE WHEN (song.feature & 1) != 0 THEN " + lnmode + " ELSE 0 END))";
-            }
-        }
-        return SongBar.toSongBarArray(main.getSongDatabase().getSongDatas(effectiveSql,main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + "/score.db"
+        return SongBar.toSongBarArray(main.getSongDatabase().getSongDatas(getEffectiveSql(main),main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + "/score.db"
         		,main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + "/scorelog.db",main.getInfoDatabase() != null ? "songinfo.db" : null));
     }
 
     public void updateFolderStatus() {
     	final MainController main = selector.main;
+        updateFolderStatus(main.getSongDatabase().getSongDatas(getEffectiveSql(main),main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + "/score.db"
+        		,main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + "/scorelog.db",main.getInfoDatabase() != null ? "songinfo.db" : null));
+    }
+
+    private String getEffectiveSql(MainController main) {
         String effectiveSql = sql;
         if (effectiveSql.contains("score.") || effectiveSql.contains("scorelog.")) {
             int lnmode = main.getPlayerConfig().getLnmode();
-            effectiveSql = "(" + effectiveSql + ") AND score.mode = (CASE WHEN (song.feature & 1) != 0 THEN " + lnmode + " ELSE 0 END)";
-            if (sql.contains("scorelog.")) {
-                effectiveSql += " AND (scorelog.sha256 IS NULL OR scorelog.mode = (CASE WHEN (song.feature & 1) != 0 THEN " + lnmode + " ELSE 0 END))";
+            
+            String upper = effectiveSql.toUpperCase();
+            int splitIdx = effectiveSql.length();
+            int orderByIdx = upper.indexOf("ORDER BY");
+            int limitIdx = upper.indexOf("LIMIT");
+            if (orderByIdx >= 0) {
+                splitIdx = orderByIdx;
+            } else if (limitIdx >= 0) {
+                splitIdx = limitIdx;
             }
+            String condition = effectiveSql.substring(0, splitIdx).trim();
+            String orderLimit = effectiveSql.substring(splitIdx).trim();
+            
+            condition = "(" + condition + ") AND score.mode = (CASE WHEN (song.feature & 1) != 0 THEN " + lnmode + " ELSE 0 END)";
+            if (sql.contains("scorelog.")) {
+                condition += " AND (scorelog.sha256 IS NULL OR scorelog.mode = (CASE WHEN (song.feature & 1) != 0 THEN " + lnmode + " ELSE 0 END))";
+            }
+            effectiveSql = condition + " " + orderLimit;
         }
-        updateFolderStatus(main.getSongDatabase().getSongDatas(effectiveSql,main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + "/score.db"
-        		,main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + "/scorelog.db",main.getInfoDatabase() != null ? "songinfo.db" : null));
+        return effectiveSql;
     }
 }

--- a/core/src/bms/player/beatoraja/skin/property/EventFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/EventFactory.java
@@ -391,13 +391,29 @@ public class EventFactory {
 			}
 		}),
 		notesdisplaytiming(74, (state, arg1) -> {
+			PlayConfig pc = null;
 			if(state instanceof MusicSelector selector) {
-				PlayConfig pc = selector.getSelectedBarPlayConfig();
+				pc = selector.getSelectedBarPlayConfig();
+			} else if (state instanceof bms.player.beatoraja.play.BMSPlayer player) {
+				if (player.getLanerender() != null) {
+					pc = player.getLanerender().getPlayConfig();
+				}
+			} else {
+				pc = state.resource.getPlayerConfig().getPlayConfig(state.resource.getPlayerConfig().getMode()).getPlayconfig();
+			}
+
+			if (pc != null) {
 				int inc = arg1 >= 0 ? (pc.getJudgetiming() < PlayConfig.JUDGETIMING_MAX ? 1 : 0)
 						: (pc.getJudgetiming() > PlayConfig.JUDGETIMING_MIN ? -1 : 0);
 				if(inc != 0) {
 					pc.setJudgetiming(pc.getJudgetiming() + inc);
-				}	
+					if (state instanceof bms.player.beatoraja.play.BMSPlayer player) {
+						state.resource.getPlayerConfig().getPlayConfig(player.getMode()).getPlayconfig().setJudgetiming(pc.getJudgetiming());
+					}
+				}
+			}
+
+			if(state instanceof MusicSelector) {
 				state.play(OPTION_CHANGE);
 			}
 		}),

--- a/core/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
+++ b/core/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
@@ -211,6 +211,25 @@ public class SQLiteSongDatabaseAccessor extends SQLiteDatabaseAccessor implement
 		return SongData.EMPTY;
 	}
 
+	private String insertGroupBy(String sql) {
+		if (sql == null) return "1 = 1 GROUP BY song.sha256";
+		String upper = sql.toUpperCase();
+		if (upper.contains("GROUP BY")) {
+			return sql;
+		}
+		int orderByIdx = upper.indexOf("ORDER BY");
+		int limitIdx = upper.indexOf("LIMIT");
+
+		int insertIdx = sql.length();
+		if (orderByIdx >= 0) {
+			insertIdx = orderByIdx;
+		} else if (limitIdx >= 0) {
+			insertIdx = limitIdx;
+		}
+
+		return sql.substring(0, insertIdx) + " GROUP BY song.sha256 " + sql.substring(insertIdx);
+	}
+
 	public SongData[] getSongDatas(String sql, String score, String scorelog, String info) {
       	try (Connection conn = qr.getDataSource().getConnection()) {
             try (Statement stmt = conn.createStatement()) {
@@ -220,18 +239,18 @@ public class SQLiteSongDatabaseAccessor extends SQLiteDatabaseAccessor implement
 
                 if(info != null) {
                     stmt.execute("ATTACH DATABASE '" + info + "' as infodb");
-                    String s = "SELECT DISTINCT md5, song.sha256 AS sha256, title, subtitle, genre, artist, subartist,path,folder,stagefile,banner,backbmp,parent,level,difficulty,"
+                    String s = "SELECT md5, song.sha256 AS sha256, title, subtitle, genre, artist, subartist,path,folder,stagefile,banner,backbmp,parent,level,difficulty,"
                             + "maxbpm,minbpm,song.mode AS mode, judge, feature, content, song.date AS date, favorite, song.notes AS notes, adddate, preview, length, charthash"
                             + " FROM song INNER JOIN (information LEFT OUTER JOIN (score LEFT OUTER JOIN scorelog ON score.sha256 = scorelog.sha256) ON information.sha256 = score.sha256) "
-                            + "ON song.sha256 = information.sha256 WHERE " + sql;
+                            + "ON song.sha256 = information.sha256 WHERE " + insertGroupBy(sql);
                     ResultSet rs = stmt.executeQuery(s);
                     m = songhandler.handle(rs);
     				// System.out.println(s + " -> result : " + m.size());
                     stmt.execute("DETACH DATABASE infodb");
                 } else {
-                    String s = "SELECT DISTINCT md5, song.sha256 AS sha256, title, subtitle, genre, artist, subartist,path,folder,stagefile,banner,backbmp,parent,level,difficulty,"
+                    String s = "SELECT md5, song.sha256 AS sha256, title, subtitle, genre, artist, subartist,path,folder,stagefile,banner,backbmp,parent,level,difficulty,"
                             + "maxbpm,minbpm,song.mode AS mode, judge, feature, content, song.date AS date, favorite, song.notes AS notes, adddate, preview, length, charthash"
-                            + " FROM song LEFT OUTER JOIN (score LEFT OUTER JOIN scorelog ON score.sha256 = scorelog.sha256) ON song.sha256 = score.sha256 WHERE " + sql;
+                            + " FROM song LEFT OUTER JOIN (score LEFT OUTER JOIN scorelog ON score.sha256 = scorelog.sha256) ON song.sha256 = score.sha256 WHERE " + insertGroupBy(sql);
                     ResultSet rs = stmt.executeQuery(s);
                     m = songhandler.handle(rs);
                 }


### PR DESCRIPTION
## 概要
判定自動調節機能の不具合修正と、カスタムフォルダでのSQL構文エラーおよびソート制約の修正を行いました。あわせて、バージョンを `1.2.5` に更新しています。

## 変更内容
1. **判定自動調節機能の修正**
   - オートアジャスト作動時、マスターの `PlayConfig` だけでなく `LaneRenderer` が保持する描画用の `PlayConfig` にも値を同期するように修正しました。
   - 異常な値に振り切れないよう `MathUtils.clamp` による範囲制限を追加しました。
   - `EventFactory` での判定タイミング手動調整時も、プレイ中の `LaneRenderer` が更新されるよう処理を修正しました。
2. **カスタムフォルダのSQL構文エラーとソート制約の修正**
   - `CommandBar.java` でLNモードのフィルタリング条件を追加する際、`ORDER BY` や `LIMIT` 句がカッコ `()` の中に入らないように分離する処理を追加しました。
   - `SQLiteSongDatabaseAccessor.java` で `SELECT DISTINCT` と `ORDER BY` の組み合わせによるカラム制限エラーを回避するため、`DISTINCT` を外し、代わりに `GROUP BY song.sha256` をクエリの適切な位置に動的に挿入する処理を追加しました。
3. **バージョン更新**
   - バージョン情報を `1.2.5` に更新し、プレリリース用サフィックス（`-beta.1`）を削除しました。
