### PR TITLE
feat(select): 選曲リストにお気に入りマーカーを表示

### DIFF
--- a/core/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/core/src/bms/player/beatoraja/select/BarRenderer.java
@@ -11,6 +11,7 @@ import bms.player.beatoraja.select.bar.*;
 import bms.player.beatoraja.skin.*;
 import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.gdx.utils.IntSet.IntSetIterator;
@@ -32,6 +33,18 @@ public final class BarRenderer {
 	private final BarManager manager;
 	
 	private final String[] TROPHY = { "bronzemedal", "silvermedal", "goldmedal" };
+
+	/** お気に入りマーカー。ソースの文字コードに依存しないようコードポイントで定義 */
+	private static final char FAVORITE_MARK = 0x2605;
+	private static final String FAVORITE_MARK_TEXT = String.valueOf(FAVORITE_MARK);
+	/**
+	 * マーカーの右端をバーの右端からどれだけ内側に置くか。文字の高さに対する倍率。
+	 * 描画されたマーカーの幅は取得できないが、★はほぼ正方形なので高さを幅の目安に使う。
+	 * 倍率はスキンがスクロールバー等の余白情報を持たないため実測から決めた値
+	 */
+	private static final float FAVORITE_MARK_MARGIN = 2f;
+	/** マーカー描画時の色の退避先。フレーム毎に生成しないよう使い回す */
+	private final Color orgcolor = new Color();
 
 	private final int durationlow;
 	private final int durationhigh;
@@ -219,6 +232,8 @@ public final class BarRenderer {
 					bartextCharset.add(c);
 				}
 			}
+			// お気に入りマーカーは曲名に含まれないため、常にフォント生成対象に加える
+			bartextCharset.add(FAVORITE_MARK);
 			char[] chars = new char[bartextCharset.size];
 			int i = 0;
 			for (IntSetIterator iterator = bartextCharset.iterator();iterator.hasNext;) {
@@ -328,8 +343,8 @@ public final class BarRenderer {
 			}
 			final SkinText text = baro.getText(ba.text);
 			if(text != null) {
-				text.setText(ba.sd.getTitle());
-				text.draw(sprite, ba.x, ba.y);				
+				drawBarTitle(sprite, text, ba, baro.getBarImages(i == skin.getCenterBar(), i),
+						skin.getWidth());
 			}
 		}
 
@@ -454,6 +469,38 @@ public final class BarRenderer {
 				baro.getLabel(1).draw(sprite, ba.x, ba.y);
 			}
 		}
+	}
+
+	/**
+	 * 楽曲バーのタイトルを描画し、お気に入り譜面にはバーの右端にマーカーを添える。
+	 * 曲名の文字列自体は変更しない(getTitle()はBarManager#setSelectedのバー特定や
+	 * タイトルソートの比較に使われるため)。
+	 * SkinTextはバー間で共有されるので、変更した状態は必ず元に戻すこと。
+	 */
+	private void drawBarTitle(SkinObjectRenderer sprite, SkinText text, BarArea ba, SkinImage bar,
+			float skinwidth) {
+		final SongData song = ba.sd instanceof SongBar ? ((SongBar) ba.sd).getSongData() : null;
+		if (bar != null && song != null
+				&& (song.getFavorite() & (SongData.FAVORITE_SONG | SongData.FAVORITE_CHART)) != 0) {
+			final int orgalign = text.getAlign();
+			// バー本体もタイトル枠も画面外まで伸びる値を設定するスキンがあるため、
+			// バーの右端と画面の右端のうち手前を採る
+			final float right = Math.min(ba.x + bar.region.width, skinwidth)
+					- text.region.height * FAVORITE_MARK_MARGIN;
+			orgcolor.set(text.color);
+			text.setAlign(SkinText.ALIGN_RIGHT);
+			// アルファは元の値を引き継ぐ。曲名をフェードさせるスキンでマーカーだけ残らないよう
+			text.color.set(Color.GOLD.r, Color.GOLD.g, Color.GOLD.b, orgcolor.a);
+			text.setText(FAVORITE_MARK_TEXT);
+			// 右寄せ時は描画された文字の右端が region.x + オフセット に来る。region.xはバー
+			// 相対座標なので、絶対座標のrightから引いた値を渡すとrightが右端になる
+			text.draw(sprite, right - text.region.x, ba.y);
+			text.setAlign(orgalign);
+			text.color.set(orgcolor);
+		}
+		// 長い曲名がマーカーに重なったとき曲名側を優先するため、マーカーより後に描く
+		text.setText(ba.sd.getTitle());
+		text.draw(sprite, ba.x, ba.y);
 	}
 
 	public void input() {


### PR DESCRIPTION
### 概要

選曲リストの楽曲バーに、お気に入り登録済みの譜面を示す金色の★を表示します。

### 背景

お気に入りの登録状態は、現状これらの方法でしか確認できません。

- コンテキストメニュー（3鍵/5鍵）を開いて `Favorite Chart` / `Favorite Song` の色を見る
- ルートの `FAVORITE SONG` / `FAVORITE CHART` フォルダを開く

いずれも**1曲ずつ、あるいは全曲横断の一覧**でしか確認できず、
「難易度表の特定レベルの中で、どれをお気に入りにしていたか」を把握できません。
リストを見ながら選曲する場面で毎回メニューを開くのは現実的ではありません。

選曲リスト上で直接判別できれば、フォルダを移動したりメニューを開いたりせずに済みます。

### 変更内容

`BarRenderer` のみ、1ファイルの変更です。

- 楽曲バーの描画時、`FAVORITE_SONG` または `FAVORITE_CHART` が立っていれば
  バー右端に★(U+2605)を金色で描画する
- ★は曲名より**先に**描画するため、長い曲名と重なった場合は曲名が優先される
- フォント生成用の文字集合に★を追加（曲名に含まれない文字のため）

### 設計上の判断

レビューで論点になりそうな箇所を先に説明します。

#### 曲名の描画処理には手を入れていない

お気に入り以外の楽曲バーは、変更前と**完全に同じ2行**を通ります。
スキンが指定した `overflow` や枠幅を上書きしていないため、既存の表示は変わりません。

「★の幅ぶん曲名を切り詰める」案も検討しましたが、
スキン作者が指定した表示ルールをコアが上書きすることになるため採用していません。

#### `Bar#getTitle()` は変更していない

曲名の文字列自体は変更せず、描画に渡す文字列を分けています。

`Bar#getTitle()` は以下で文字列一致に使われており、変更すると影響が出ます。

- `BarManager#setSelected`（`BarManager.java:651`）が対象バーの特定に使用。型判定が無く `SongBar` も対象
- タイトルソートで `SongBar` と `FolderBar` を比較する場合（`BarSorter.java:41`）

なお `updateBar` のカーソル位置復元は、`SongBar` については sha256 一致で行われるため
（`BarManager.java:534-536`）、この経路は影響を受けません。

#### 表示位置は「バーの右端」と「画面の右端」の手前を採る

```java
final float right = Math.min(ba.x + bar.region.width, skinwidth) - text.region.height * FAVORITE_MARK_MARGIN;
```

タイトル枠(`#DST_BAR_TITLE` 等)の幅は位置の基準に使えませんでした。実測値は以下の通りです。

| スキン | タイトル枠の幅 | バー本体の右端 |
|---|---|---|
| ModernChic | 500 | 2085 |
| LITONE5 | **2048**（「制限なし」の意味） | 1950 |
| default | 小さい | — |

バー本体も画面幅(1920)を超える値が設定されており、
**「バーの見た目上の右端」を表す値はスキン側に存在しません**。
そのため画面幅で上限を設けています。曲リストが右端にないスキンでは
バーの右端が採用されるため、レイアウトを仮定していません。

余白の係数 `FAVORITE_MARK_MARGIN = 2f` は、スキンがスクロールバー等の
余白情報を持たないため、複数スキンでの実測から決めた値です。

#### 色をコア側で決めている

`SkinDistributionGraph` がクリアランプ／ランクの色をコアに直書きしている前例
（`SkinDistributionGraph.java:39-45`）に倣いました。
スキン側に定義を要求する方式も検討しましたが、対応スキンが現れるまで
誰の画面にも表示されず機能しないため採用していません。

#### ON/OFF 設定は設けていない

- ★が出るのは**ユーザー自身が登録した曲だけ**で、お気に入りを使っていない場合は表示が一切変わらない
- 前例の `SkinDistributionGraph` にも無効化設定は無い
- 設定を追加すると `PlayerConfig` の変更と設定ファイル互換の検討が必要になり、
  本PRの主題から外れる

必要という判断であれば、Mod Menu の `MiscSettingMenu` へのトグル追加で対応できます。

### 動作確認

スキン形式とテキスト描画実装の全経路を確認しました。

| スキン | 形式 | フォント | 描画実装 | 結果 |
|---|---|---|---|---|
| default | JSON | `VL-Gothic-Regular.ttf` | `SkinTextFont` | OK |
| ModernChic | Lua | `Select/font/fnt/bartext.fnt` | `SkinTextBitmap` | OK |
| LITONE5 | LR2 CSV | `Select/font/bartitle/font.lr2font` | `SkinTextImage` | OK |

確認項目

- 3スキンとも★がバー右端の一定位置に表示される
- スクロールバーと重ならない
- お気に入りでない曲には表示されない
- ★の付いた曲の次以降のバーで、文字揃え・文字色が変化しない（共有オブジェクトの復元確認）
- 長い曲名では曲名が★の上に描画される

### 既存への影響

| 対象 | 影響 |
|---|---|
| お気に入り未使用のユーザー | 表示の変化なし |
| スキン | 新しい定義を要求しない。既存スキンの改修不要 |
| 設定ファイル | 変更なし |
| `getTitle()` の利用箇所（バー特定・ソート・カーソル復元・テーブル名） | 変更なし |

### 既知の制約

- **長い曲名では★が曲名の下に隠れます。** 曲名の情報を優先する判断です
- **バーの右側にランプやレベル数値を配置するスキンでは★が隠れる可能性があります。**
  `BarRenderer#render` の描画順がテキスト→トロフィー→ランプ→レベル数値のためです。
  描画順の変更は影響範囲が大きいため本PRでは対応していません
- 余白の係数は実測に基づく値で、理論的な根拠はありません

### 採用しなかった案

| 案 | 見送った理由 |
|---|---|
| 難易度表フォルダのコンテキストメニューに絞り込みを追加 | 毎回メニューを開く必要があり、状態が持続しない |
| スキンのテキストスタイル番号(`BARTEXT`)を追加 | 対応スキンが現れるまで表示されない |
| ラベル画像として追加 | 同上。加えて LN/MINE/RANDOM ラベルと描画位置が競合する |
| 曲名の直後に★を置く | 長い曲名では★が画面外に出る |
| 曲名を切り詰めて★用の余白を作る | スキンが指定した `overflow` 設定の上書きになる |

---

## スクリーンショット

以下はいずれもお気に入り登録済みの譜面に★が表示されている状態です。
曲名の描画処理には手を入れていないため、変更前との差分は★の有無のみです。

### default（JSON + TTF / `SkinTextFont`）

<img width="1920" height="1080" alt="default" src="https://github.com/user-attachments/assets/093b4525-2ab0-4876-ac99-dbf65171cdd6" />

### ModernChic（Lua + `.fnt` / `SkinTextBitmap`）

<img width="1920" height="1080" alt="ModernChic" src="https://github.com/user-attachments/assets/6cb444be-962b-47ab-b378-587fcfcd60c5" />

### LITONE5（LR2 CSV + `.lr2font` / `SkinTextImage`）

<img width="1920" height="1080" alt="LITONE5" src="https://github.com/user-attachments/assets/bb62b56d-b391-45d7-9d08-7f3aa488f179" />
